### PR TITLE
update yt-dlp from 2023.10.07 to 2023.10.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2023.10.07
+export YTDLP_VERSION := 2023.10.13
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -539,7 +539,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2203,7 +2203,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3538,7 +3538,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4152,9 +4152,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4179,8 +4179,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4206,7 +4206,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4247,7 +4247,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4288,7 +4288,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -4837,7 +4837,7 @@ func (c *Command) UnsetNetrcCmd() *Command {
 	return c
 }
 
-// Video password (vimeo, youku)
+// Video-specific password
 //
 // Additional information:
 //   - See [Command.UnsetVideoPassword], for unsetting the flag.
@@ -5463,8 +5463,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5491,8 +5491,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5552,7 +5552,7 @@ var (
 // concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5816,7 +5816,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6380,7 +6380,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2023.10.07"
+	Version = "2023.10.13"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -693,6 +693,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Joj"},
 	{Name: "Jove"},
 	{Name: "JStream"},
+	{Name: "JTBC", Description: "jtbc.co.kr", AgeLimit: 15},
+	{Name: "JTBC:program"},
 	{Name: "JWPlatform"},
 	{Name: "Kakao"},
 	{Name: "Kaltura"},
@@ -803,6 +805,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "massengeschmack.tv"},
 	{Name: "Masters"},
 	{Name: "MatchTV"},
+	{Name: "MBN", Description: "mbn.co.kr (매일방송)"},
 	{Name: "MDR", Description: "MDR.DE and KiKA"},
 	{Name: "MedalTV"},
 	{Name: "media.ccc.de"},
@@ -1509,6 +1512,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Tempo"},
 	{Name: "TennisTV", Description: "[tennistv]"},
 	{Name: "TenPlay", Description: "[10play]", AgeLimit: 15},
+	{Name: "TenPlaySeason"},
 	{Name: "TestURL", Description: "[HIDDEN]"},
 	{Name: "TF1"},
 	{Name: "TFO"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -729,7 +729,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -758,7 +758,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1036,7 +1036,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2001,7 +2001,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2757,7 +2757,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3093,15 +3093,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3122,11 +3122,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3147,7 +3147,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3177,7 +3177,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3205,7 +3205,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3526,7 +3526,7 @@ var (
 		DefaultFlag:    "--video-password",
 		ArgNames:       []string{"password"},
 		Executable:     false,
-		Help:           "Video password (vimeo, youku)",
+		Help:           "Video-specific password",
 		MetaArgs:       "PASSWORD",
 		Type:           "string",
 		LongFlags:      []string{"--video-password"},
@@ -3886,11 +3886,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -3910,11 +3910,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -3945,7 +3945,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4097,7 +4097,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4413,7 +4413,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.07/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2023.10.07`](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.10.07) to [`2023.10.13`](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.10.13).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.10.13)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.