### PR TITLE
update yt-dlp from 2023.10.13 to 2023.11.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2023.10.13
+export YTDLP_VERSION := 2023.11.16
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -69,10 +69,10 @@ func (c *Command) UnsetUpdate() *Command {
 
 // Upgrade/downgrade to a specific version. CHANNEL can be a repository as well.
 // CHANNEL and TAG default to "stable" and "latest" respectively if omitted; See
-// "UPDATE" for details. Supported channels: stable, nightly
+// "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -539,7 +539,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2203,7 +2203,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3538,7 +3538,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4152,9 +4152,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4179,8 +4179,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4206,7 +4206,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4247,7 +4247,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4288,7 +4288,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5463,8 +5463,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5491,8 +5491,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5552,7 +5552,7 @@ var (
 // concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5816,7 +5816,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6380,7 +6380,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2023.10.13"
+	Version = "2023.11.16"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -446,6 +446,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "EllenTubeVideo"},
 	{Name: "Elonet"},
 	{Name: "ElPais", Description: "El País"},
+	{Name: "ElTreceTV", Description: "El Trece TV (Argentina)"},
 	{Name: "Embedly"},
 	{Name: "EMPFlix", AgeLimit: 18},
 	{Name: "Engadget"},
@@ -690,6 +691,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Jamendo"},
 	{Name: "JamendoAlbum"},
 	{Name: "JeuxVideo"},
+	{Name: "JioSaavnAlbum"},
+	{Name: "JioSaavnSong"},
 	{Name: "Joj"},
 	{Name: "Jove"},
 	{Name: "JStream"},
@@ -736,6 +739,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "LastFM"},
 	{Name: "LastFMPlaylist"},
 	{Name: "LastFMUser"},
+	{Name: "LaXarxaMes", Description: "[laxarxames]"},
 	{Name: "lbry"},
 	{Name: "lbry:channel"},
 	{Name: "lbry:playlist"},
@@ -1013,7 +1017,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Nitter"},
 	{Name: "njoy", Description: "N-JOY"},
 	{Name: "njoy:embed"},
-	{Name: "NJPWWorld", Description: "[njpwworld] 新日本プロレスワールド"},
 	{Name: "NobelPrize"},
 	{Name: "NoicePodcast"},
 	{Name: "NonkTube", AgeLimit: 18},
@@ -1063,7 +1066,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "OlympicsReplay"},
 	{Name: "on24", Description: "ON24"},
 	{Name: "OnDemandChinaEpisode"},
-	{Name: "OnDemandKorea"},
+	{Name: "OnDemandKorea", AgeLimit: 18},
+	{Name: "OnDemandKoreaProgram"},
 	{Name: "OneFootball"},
 	{Name: "OnePlacePodcast"},
 	{Name: "onet.pl"},
@@ -1081,6 +1085,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "OraTV"},
 	{Name: "orf:fm4:story", Description: "fm4.orf.at stories"},
 	{Name: "orf:iptv", Description: "iptv.ORF.at"},
+	{Name: "orf:podcast"},
 	{Name: "orf:radio"},
 	{Name: "orf:tvthek", Description: "ORF TVthek"},
 	{Name: "OsnatelTV", Description: "[osnateltv]"},
@@ -1219,6 +1224,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "radiobremen"},
 	{Name: "radiocanada"},
 	{Name: "radiocanada:audiovideo"},
+	{Name: "RadioComercial"},
+	{Name: "RadioComercialPlaylist"},
 	{Name: "radiofrance"},
 	{Name: "RadioFranceLive"},
 	{Name: "RadioFrancePodcast"},
@@ -1347,6 +1354,9 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Sapo", Description: "SAPO Vídeos"},
 	{Name: "savefrom.net"},
 	{Name: "SBS", Description: "sbs.com.au"},
+	{Name: "sbs.co.kr", AgeLimit: 15},
+	{Name: "sbs.co.kr:allvod_program"},
+	{Name: "sbs.co.kr:programs_vod"},
 	{Name: "schooltv"},
 	{Name: "ScienceChannel"},
 	{Name: "screen.yahoo:search", Description: "Yahoo screen search; \"yvsearch:\" prefix"},
@@ -1516,6 +1526,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "TestURL", Description: "[HIDDEN]"},
 	{Name: "TF1"},
 	{Name: "TFO"},
+	{Name: "theatercomplextown:ppv", Description: "[theatercomplextown]"},
+	{Name: "theatercomplextown:vod", Description: "[theatercomplextown]"},
 	{Name: "TheHoleTv"},
 	{Name: "TheIntercept"},
 	{Name: "ThePlatform"},
@@ -1524,8 +1536,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "TheSun"},
 	{Name: "TheWeatherChannel"},
 	{Name: "ThisAmericanLife"},
-	{Name: "ThisAV"},
-	{Name: "ThisOldHouse"},
+	{Name: "ThisOldHouse", Description: "[thisoldhouse]"},
 	{Name: "ThisVid", AgeLimit: 18},
 	{Name: "ThisVidMember"},
 	{Name: "ThisVidPlaylist", AgeLimit: 18},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -729,7 +729,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -758,13 +758,13 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
 		ArgNames:    []string{"value"},
 		Executable:  true,
-		Help:        "Upgrade/downgrade to a specific version. CHANNEL can be a repository as well. CHANNEL and TAG default to \"stable\" and \"latest\" respectively if omitted; See \"UPDATE\" for details. Supported channels: stable, nightly",
+		Help:        "Upgrade/downgrade to a specific version. CHANNEL can be a repository as well. CHANNEL and TAG default to \"stable\" and \"latest\" respectively if omitted; See \"UPDATE\" for details. Supported channels: stable, nightly, master",
 		MetaArgs:    "[CHANNEL]@[TAG]",
 		Type:        "string",
 		LongFlags:   []string{"--update-to"},
@@ -1036,7 +1036,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2001,7 +2001,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2757,7 +2757,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3093,15 +3093,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3122,11 +3122,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3147,7 +3147,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3177,7 +3177,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3205,7 +3205,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3886,11 +3886,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -3910,11 +3910,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -3945,7 +3945,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4097,7 +4097,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4413,7 +4413,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.10.13/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2023.11.16/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2023.10.13`](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.10.13) to [`2023.11.16`](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.11.16).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.11.16)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.