### PR TITLE
update yt-dlp from 2024.03.10 to 2024.04.09

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2024.03.10
+export YTDLP_VERSION := 2024.04.09
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -539,7 +539,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -628,6 +628,51 @@ func (c *Command) SourceAddress(ip string) *Command {
 //   - [Command.SourceAddress]
 func (c *Command) UnsetSourceAddress() *Command {
 	c.removeFlagByID("source_address")
+	return c
+}
+
+// Client to impersonate for requests. E.g. chrome, chrome-110, chrome:windows-10.
+// Pass --impersonate="" to impersonate any client.
+//
+// Additional information:
+//   - See [Command.UnsetImpersonate], for unsetting the flag.
+//   - Impersonate maps to cli flags: --impersonate=CLIENT[:OS].
+//   - From option group: "Network"
+func (c *Command) Impersonate(client string) *Command {
+	c.addFlag(&Flag{
+		ID:   "impersonate",
+		Flag: "--impersonate",
+		Args: []string{client},
+	})
+	return c
+}
+
+// UnsetImpersonate unsets any flags that were previously set by one of:
+//   - [Command.Impersonate]
+func (c *Command) UnsetImpersonate() *Command {
+	c.removeFlagByID("impersonate")
+	return c
+}
+
+// List available clients to impersonate.
+//
+// Additional information:
+//   - See [Command.UnsetListImpersonateTargets], for unsetting the flag.
+//   - ListImpersonateTargets maps to cli flags: --list-impersonate-targets.
+//   - From option group: "Network"
+func (c *Command) ListImpersonateTargets() *Command {
+	c.addFlag(&Flag{
+		ID:   "list_impersonate_targets",
+		Flag: "--list-impersonate-targets",
+		Args: nil,
+	})
+	return c
+}
+
+// UnsetListImpersonateTargets unsets any flags that were previously set by one of:
+//   - [Command.ListImpersonateTargets]
+func (c *Command) UnsetListImpersonateTargets() *Command {
+	c.removeFlagByID("list_impersonate_targets")
 	return c
 }
 
@@ -1362,8 +1407,25 @@ func (c *Command) BreakOnExisting() *Command {
 
 // UnsetBreakOnExisting unsets any flags that were previously set by one of:
 //   - [Command.BreakOnExisting]
+//   - [Command.NoBreakOnExisting]
 func (c *Command) UnsetBreakOnExisting() *Command {
 	c.removeFlagByID("break_on_existing")
+	return c
+}
+
+// Do not stop the download process when encountering a file that is in the archive
+// (default)
+//
+// Additional information:
+//   - See [Command.UnsetBreakOnExisting], for unsetting the flag.
+//   - NoBreakOnExisting maps to cli flags: --no-break-on-existing.
+//   - From option group: "Video Selection"
+func (c *Command) NoBreakOnExisting() *Command {
+	c.addFlag(&Flag{
+		ID:   "break_on_existing",
+		Flag: "--no-break-on-existing",
+		Args: nil,
+	})
 	return c
 }
 
@@ -2203,7 +2265,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3538,7 +3600,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -3735,6 +3797,30 @@ func (c *Command) ProgressTemplate(template string) *Command {
 //   - [Command.ProgressTemplate]
 func (c *Command) UnsetProgressTemplate() *Command {
 	c.removeFlagByID("progress_template")
+	return c
+}
+
+// Time between progress output (default: 0)
+//
+// Additional information:
+//   - See [Command.UnsetProgressDelta], for unsetting the flag.
+//   - ProgressDelta maps to cli flags: --progress-delta=SECONDS.
+//   - From option group: "Verbosity Simulation"
+func (c *Command) ProgressDelta(seconds float64) *Command {
+	c.addFlag(&Flag{
+		ID:   "progress_delta",
+		Flag: "--progress-delta",
+		Args: []string{
+			strconv.FormatFloat(seconds, 'g', -1, 64),
+		},
+	})
+	return c
+}
+
+// UnsetProgressDelta unsets any flags that were previously set by one of:
+//   - [Command.ProgressDelta]
+func (c *Command) UnsetProgressDelta() *Command {
+	c.removeFlagByID("progress_delta")
 	return c
 }
 
@@ -4152,9 +4238,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4179,8 +4265,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4206,7 +4292,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4247,7 +4333,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4288,7 +4374,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5463,8 +5549,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5491,8 +5577,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5552,7 +5638,7 @@ var (
 // concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5816,7 +5902,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6380,7 +6466,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/builder.gen_test.go
+++ b/builder.gen_test.go
@@ -190,6 +190,18 @@ func TestBuilder_Network_NonExecutable(t *testing.T) {
 		_ = builder.UnsetSourceAddress()
 		validateFlagRemoved(t, builder, "source_address", "--source-address")
 	})
+	t.Run("Impersonate", func(t *testing.T) {
+		builder := New().Impersonate("test")
+		validateFlagAdded(t, builder, "impersonate", "--impersonate", 1)
+		_ = builder.UnsetImpersonate()
+		validateFlagRemoved(t, builder, "impersonate", "--impersonate")
+	})
+	t.Run("ListImpersonateTargets", func(t *testing.T) {
+		builder := New().ListImpersonateTargets()
+		validateFlagAdded(t, builder, "list_impersonate_targets", "--list-impersonate-targets", 0)
+		_ = builder.UnsetListImpersonateTargets()
+		validateFlagRemoved(t, builder, "list_impersonate_targets", "--list-impersonate-targets")
+	})
 	t.Run("ForceIPv4", func(t *testing.T) {
 		builder := New().ForceIPv4()
 		validateFlagAdded(t, builder, "source_address", "--force-ipv4", 0)
@@ -395,6 +407,12 @@ func TestBuilder_VideoSelection_NonExecutable(t *testing.T) {
 		validateFlagAdded(t, builder, "break_on_existing", "--break-on-existing", 0)
 		_ = builder.UnsetBreakOnExisting()
 		validateFlagRemoved(t, builder, "break_on_existing", "--break-on-existing")
+	})
+	t.Run("NoBreakOnExisting", func(t *testing.T) {
+		builder := New().NoBreakOnExisting()
+		validateFlagAdded(t, builder, "break_on_existing", "--no-break-on-existing", 0)
+		_ = builder.UnsetBreakOnExisting()
+		validateFlagRemoved(t, builder, "break_on_existing", "--no-break-on-existing")
 	})
 	t.Run("BreakOnReject", func(t *testing.T) {
 		builder := New().BreakOnReject()
@@ -1081,6 +1099,12 @@ func TestBuilder_VerbositySimulation_NonExecutable(t *testing.T) {
 		validateFlagAdded(t, builder, "progress_template", "--progress-template", 1)
 		_ = builder.UnsetProgressTemplate()
 		validateFlagRemoved(t, builder, "progress_template", "--progress-template")
+	})
+	t.Run("ProgressDelta", func(t *testing.T) {
+		builder := New().ProgressDelta(1.0)
+		validateFlagAdded(t, builder, "progress_delta", "--progress-delta", 1)
+		_ = builder.UnsetProgressDelta()
+		validateFlagRemoved(t, builder, "progress_delta", "--progress-delta")
 	})
 	t.Run("Verbose", func(t *testing.T) {
 		builder := New().Verbose()

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2024.03.10"
+	Version = "2024.04.09"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -77,7 +77,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "aenetworks:show"},
 	{Name: "AeonCo"},
 	{Name: "afreecatv", Description: "[afreecatv] afreecatv.com"},
-	{Name: "afreecatv:live", Description: "[afreecatv] afreecatv.com"},
+	{Name: "afreecatv:live", Description: "[afreecatv] afreecatv.com livestreams"},
 	{Name: "afreecatv:user"},
 	{Name: "AirTV"},
 	{Name: "AitubeKZVideo"},
@@ -135,6 +135,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "ArteTVPlaylist"},
 	{Name: "asobichannel", Description: "ASOBI CHANNEL"},
 	{Name: "asobichannel:tag", Description: "ASOBI CHANNEL"},
+	{Name: "AsobiStage", Description: "ASOBISTAGE (アソビステージ)"},
 	{Name: "AtresPlayer", Description: "[atresplayer]"},
 	{Name: "AtScaleConfEvent"},
 	{Name: "ATVAt"},
@@ -469,6 +470,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "FacebookRedirectURL", Description: "[HIDDEN]"},
 	{Name: "fancode:live", Description: "[fancode] (Currently broken)"},
 	{Name: "fancode:vod", Description: "[fancode] (Currently broken)"},
+	{Name: "Fathom"},
 	{Name: "faz.net"},
 	{Name: "fc2", Description: "[fc2]"},
 	{Name: "fc2:embed"},
@@ -669,8 +671,9 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Jamendo"},
 	{Name: "JamendoAlbum"},
 	{Name: "JeuxVideo", Description: "(Currently broken)"},
-	{Name: "JioSaavnAlbum"},
-	{Name: "JioSaavnSong"},
+	{Name: "jiosaavn:album"},
+	{Name: "jiosaavn:playlist"},
+	{Name: "jiosaavn:song"},
 	{Name: "Joj"},
 	{Name: "JoqrAg", Description: "超!A&G+ 文化放送 (f.k.a. AGQR) Nippon Cultural Broadcasting, Inc. (JOQR)"},
 	{Name: "Jove"},
@@ -753,6 +756,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Lnk"},
 	{Name: "LnkGo", AgeLimit: 18},
 	{Name: "loc", Description: "Library of Congress"},
+	{Name: "loom"},
+	{Name: "loom:folder"},
 	{Name: "LoveHomePorn", AgeLimit: 18},
 	{Name: "LRTStream"},
 	{Name: "LRTVOD"},
@@ -1175,6 +1180,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Radiko"},
 	{Name: "RadikoRadio"},
 	{Name: "radio.de", Description: "(Currently broken)"},
+	{Name: "Radio1Be"},
 	{Name: "radiocanada"},
 	{Name: "radiocanada:audiovideo"},
 	{Name: "RadioComercial"},
@@ -1329,6 +1335,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "SeznamZpravyArticle"},
 	{Name: "Shahid", Description: "[shahid]"},
 	{Name: "ShahidShow"},
+	{Name: "SharePoint"},
 	{Name: "ShareVideosEmbed"},
 	{Name: "ShemarooMe"},
 	{Name: "ShowRoomLive"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -66,6 +66,8 @@ var (
 			optionProxy,
 			optionSocketTimeout,
 			optionSourceAddress,
+			optionImpersonate,
+			optionListImpersonateTargets,
 			optionForceIPv4,
 			optionForceIPv6,
 			optionEnableFileURLs,
@@ -109,6 +111,7 @@ var (
 			optionNoDownloadArchive,
 			optionMaxDownloads,
 			optionBreakOnExisting,
+			optionNoBreakOnExisting,
 			optionBreakOnReject,
 			optionBreakPerInput,
 			optionNoBreakPerInput,
@@ -245,6 +248,7 @@ var (
 			optionProgress,
 			optionConsoleTitle,
 			optionProgressTemplate,
+			optionProgressDelta,
 			optionVerbose,
 			optionDumpPages,
 			optionWritePages,
@@ -440,6 +444,8 @@ var Options = []*Option{
 	optionProxy,
 	optionSocketTimeout,
 	optionSourceAddress,
+	optionImpersonate,
+	optionListImpersonateTargets,
 	optionForceIPv4,
 	optionForceIPv6,
 	optionEnableFileURLs,
@@ -473,6 +479,7 @@ var Options = []*Option{
 	optionNoDownloadArchive,
 	optionMaxDownloads,
 	optionBreakOnExisting,
+	optionNoBreakOnExisting,
 	optionBreakOnReject,
 	optionBreakPerInput,
 	optionNoBreakPerInput,
@@ -584,6 +591,7 @@ var Options = []*Option{
 	optionProgress,
 	optionConsoleTitle,
 	optionProgressTemplate,
+	optionProgressDelta,
 	optionVerbose,
 	optionDumpPages,
 	optionWritePages,
@@ -729,7 +737,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -758,7 +766,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1036,7 +1044,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -1089,6 +1097,31 @@ var (
 		Type:           "string",
 		LongFlags:      []string{"--source-address"},
 		NArgs:          1,
+	}
+	optionImpersonate = &Option{
+		ID:             "impersonate",
+		Name:           "impersonate",
+		NameCamelCase:  "impersonate",
+		NamePascalCase: "Impersonate",
+		DefaultFlag:    "--impersonate",
+		ArgNames:       []string{"client"},
+		Executable:     false,
+		Help:           "Client to impersonate for requests. E.g. chrome, chrome-110, chrome:windows-10. Pass --impersonate=\"\" to impersonate any client.",
+		MetaArgs:       "CLIENT[:OS]",
+		Type:           "string",
+		LongFlags:      []string{"--impersonate"},
+		NArgs:          1,
+	}
+	optionListImpersonateTargets = &Option{
+		ID:             "list_impersonate_targets",
+		Name:           "list-impersonate-targets",
+		NameCamelCase:  "listImpersonateTargets",
+		NamePascalCase: "ListImpersonateTargets",
+		DefaultFlag:    "--list-impersonate-targets",
+		Executable:     false,
+		Help:           "List available clients to impersonate.",
+		Type:           "bool",
+		LongFlags:      []string{"--list-impersonate-targets"},
 	}
 	optionForceIPv4 = &Option{
 		ID:             "source_address",
@@ -1522,6 +1555,17 @@ var (
 		Help:           "Stop the download process when encountering a file that is in the archive",
 		Type:           "bool",
 		LongFlags:      []string{"--break-on-existing"},
+	}
+	optionNoBreakOnExisting = &Option{
+		ID:             "break_on_existing",
+		Name:           "no-break-on-existing",
+		NameCamelCase:  "noBreakOnExisting",
+		NamePascalCase: "NoBreakOnExisting",
+		DefaultFlag:    "--no-break-on-existing",
+		Executable:     false,
+		Help:           "Do not stop the download process when encountering a file that is in the archive (default)",
+		Type:           "bool",
+		LongFlags:      []string{"--no-break-on-existing"},
 	}
 	optionBreakOnReject = &Option{
 		ID:             "break_on_reject",
@@ -2001,7 +2045,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2757,7 +2801,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -2857,6 +2901,20 @@ var (
 		MetaArgs:       "[TYPES:]TEMPLATE",
 		Type:           "string",
 		LongFlags:      []string{"--progress-template"},
+		NArgs:          1,
+	}
+	optionProgressDelta = &Option{
+		ID:             "progress_delta",
+		Name:           "progress-delta",
+		NameCamelCase:  "progressDelta",
+		NamePascalCase: "ProgressDelta",
+		DefaultFlag:    "--progress-delta",
+		ArgNames:       []string{"seconds"},
+		Executable:     false,
+		Help:           "Time between progress output (default: 0)",
+		MetaArgs:       "SECONDS",
+		Type:           "float64",
+		LongFlags:      []string{"--progress-delta"},
 		NArgs:          1,
 	}
 	optionVerbose = &Option{
@@ -3093,15 +3151,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3122,11 +3180,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3147,7 +3205,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3177,7 +3235,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3205,7 +3263,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3886,11 +3944,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -3910,11 +3968,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -3945,7 +4003,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4097,7 +4155,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4413,7 +4471,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.03.10/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.04.09/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2024.03.10`](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.03.10) to [`2024.04.09`](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.04.09).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.04.09)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.