### PR TITLE
update yt-dlp from 2024.10.22 to 2024.11.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2024.10.22
+export YTDLP_VERSION := 2024.11.04
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -565,7 +565,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -1418,6 +1418,7 @@ func (c *Command) UnsetMaxDownloads() *Command {
 }
 
 // Stop the download process when encountering a file that is in the archive
+// supplied with the --download-archive option
 //
 // Additional information:
 //   - See [Command.UnsetBreakOnExisting], for unsetting the flag.
@@ -2292,7 +2293,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3628,7 +3629,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4266,9 +4267,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4293,8 +4294,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4320,7 +4321,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4361,7 +4362,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4402,7 +4403,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5580,8 +5581,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5608,8 +5609,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5669,7 +5670,7 @@ var (
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5934,7 +5935,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6498,7 +6499,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2024.10.22"
+	Version = "2024.11.04"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -221,6 +221,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Blob", Description: "[HIDDEN]"},
 	{Name: "blogger.com"},
 	{Name: "Bloomberg"},
+	{Name: "Bluesky", AgeLimit: 18},
 	{Name: "BokeCC"},
 	{Name: "BongaCams", AgeLimit: 18},
 	{Name: "Boosty"},
@@ -278,7 +279,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "cbsnews:livevideo", Description: "CBS News Live Videos"},
 	{Name: "cbssports", Description: "(Currently broken)"},
 	{Name: "cbssports:embed", Description: "(Currently broken)"},
-	{Name: "CCMA", AgeLimit: 16},
+	{Name: "CCMA", Description: "3Cat, TV3 and Catalunya Ràdio", AgeLimit: 13},
 	{Name: "CCTV", Description: "央视网"},
 	{Name: "CDA", Description: "[cdapl]", AgeLimit: 18},
 	{Name: "CDAFolder"},
@@ -311,8 +312,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "cmt.com", Description: "(Currently broken)"},
 	{Name: "CNBCVideo"},
 	{Name: "CNN"},
-	{Name: "CNNArticle"},
-	{Name: "CNNBlogs"},
 	{Name: "CNNIndonesia"},
 	{Name: "ComedyCentral"},
 	{Name: "ComedyCentralTV"},
@@ -722,9 +721,9 @@ var SupportedExtractors = []*Extractor{
 	{Name: "LastFMPlaylist"},
 	{Name: "LastFMUser"},
 	{Name: "LaXarxaMes", Description: "[laxarxames]"},
-	{Name: "lbry"},
-	{Name: "lbry:channel"},
-	{Name: "lbry:playlist"},
+	{Name: "lbry", Description: "odysee.com"},
+	{Name: "lbry:channel", Description: "odysee.com channels"},
+	{Name: "lbry:playlist", Description: "odysee.com playlists"},
 	{Name: "LCI"},
 	{Name: "Lcp"},
 	{Name: "LcpPlay"},
@@ -1488,7 +1487,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "TeleQuebecSquat"},
 	{Name: "TeleQuebecVideo"},
 	{Name: "TeleTask", Description: "(Currently broken)"},
-	{Name: "Telewebion"},
+	{Name: "Telewebion", Description: "(Currently broken)"},
 	{Name: "Tempo"},
 	{Name: "TennisTV", Description: "[tennistv]"},
 	{Name: "TenPlay", Description: "[10play]", AgeLimit: 15},
@@ -1553,7 +1552,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "TubeTuGrazSeries", Description: "[tubetugraz]"},
 	{Name: "tubitv", Description: "[tubitv]"},
 	{Name: "tubitv:series"},
-	{Name: "Tumblr", Description: "[tumblr]", AgeLimit: 18},
+	{Name: "Tumblr", Description: "[tumblr]"},
 	{Name: "tunein:shortener", Description: "[HIDDEN]"},
 	{Name: "TuneInPodcast"},
 	{Name: "TuneInPodcastEpisode"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -739,7 +739,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -768,7 +768,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1060,7 +1060,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -1568,7 +1568,7 @@ var (
 		NamePascalCase: "BreakOnExisting",
 		DefaultFlag:    "--break-on-existing",
 		Executable:     false,
-		Help:           "Stop the download process when encountering a file that is in the archive",
+		Help:           "Stop the download process when encountering a file that is in the archive supplied with the --download-archive option",
 		Type:           "bool",
 		LongFlags:      []string{"--break-on-existing"},
 	}
@@ -2061,7 +2061,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2815,7 +2815,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3165,15 +3165,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3194,11 +3194,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3219,7 +3219,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3249,7 +3249,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3277,7 +3277,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3958,11 +3958,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -3982,11 +3982,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4017,7 +4017,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4169,7 +4169,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4485,7 +4485,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.10.22/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2024.11.04/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2024.10.22`](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.10.22) to [`2024.11.04`](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.11.04).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.11.04)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.