### PR TITLE
update yt-dlp from 2025.01.15 to 2025.01.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2025.01.15
+export YTDLP_VERSION := 2025.01.26
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -566,7 +566,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2294,7 +2294,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3630,7 +3630,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4268,9 +4268,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4295,8 +4295,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4322,7 +4322,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4363,7 +4363,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4404,7 +4404,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5582,8 +5582,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5610,8 +5610,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5671,7 +5671,7 @@ var (
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5936,7 +5936,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6500,7 +6500,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2025.01.15"
+	Version = "2025.01.26"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -201,6 +201,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "BilibiliCheese"},
 	{Name: "BilibiliCheeseSeason"},
 	{Name: "BilibiliCollectionList"},
+	{Name: "BiliBiliDynamic"},
 	{Name: "BilibiliFavoritesList"},
 	{Name: "BiliBiliPlayer"},
 	{Name: "BilibiliPlaylist"},
@@ -335,10 +336,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "CrowdBunker"},
 	{Name: "CrowdBunkerChannel"},
 	{Name: "Crtvg"},
-	{Name: "crunchyroll", Description: "[crunchyroll]", AgeLimit: 14},
-	{Name: "crunchyroll:artist", Description: "[crunchyroll]"},
-	{Name: "crunchyroll:music", Description: "[crunchyroll]"},
-	{Name: "crunchyroll:playlist", Description: "[crunchyroll]", AgeLimit: 14},
 	{Name: "CSpan", Description: "C-SPAN"},
 	{Name: "CSpanCongress"},
 	{Name: "CtsNews", Description: "華視新聞"},
@@ -426,6 +423,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Ebay"},
 	{Name: "egghead:course", Description: "egghead.io course"},
 	{Name: "egghead:lesson", Description: "egghead.io lesson"},
+	{Name: "eggs:artist"},
+	{Name: "eggs:single"},
 	{Name: "EinsUndEinsTV", Description: "[1und1tv]"},
 	{Name: "EinsUndEinsTVLive", Description: "[1und1tv]"},
 	{Name: "EinsUndEinsTVRecordings", Description: "[1und1tv]"},
@@ -511,9 +510,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "FrontendMastersCourse", Description: "[frontendmasters]"},
 	{Name: "FrontendMastersLesson", Description: "[frontendmasters]"},
 	{Name: "FujiTVFODPlus7"},
-	{Name: "Funimation", Description: "[funimation]"},
-	{Name: "funimation:page", Description: "[funimation]"},
-	{Name: "funimation:show", Description: "[funimation]"},
 	{Name: "Funk"},
 	{Name: "Funker530"},
 	{Name: "Fux", AgeLimit: 18},
@@ -567,7 +563,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "GodTube", Description: "(Currently broken)"},
 	{Name: "Gofile"},
 	{Name: "Golem"},
-	{Name: "goodgame:stream"},
+	{Name: "goodgame:stream", AgeLimit: 18},
 	{Name: "google:podcasts"},
 	{Name: "google:podcasts:feed"},
 	{Name: "GoogleDrive"},
@@ -931,6 +927,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "nebula:video", Description: "[watchnebula]"},
 	{Name: "NekoHacker"},
 	{Name: "NerdCubedFeed"},
+	{Name: "Nest"},
+	{Name: "NestClip"},
 	{Name: "netease:album", Description: "网易云音乐 - 专辑"},
 	{Name: "netease:djradio", Description: "网易云音乐 - 电台"},
 	{Name: "netease:mv", Description: "网易云音乐 - MV"},
@@ -1111,6 +1109,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Pinterest"},
 	{Name: "PinterestCollection"},
 	{Name: "Piracy", Description: "[HIDDEN]"},
+	{Name: "PiramideTV"},
+	{Name: "PiramideTVChannel"},
 	{Name: "pixiv:sketch", AgeLimit: 18},
 	{Name: "pixiv:sketch:user"},
 	{Name: "Pladform"},
@@ -1438,6 +1438,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "StretchInternet"},
 	{Name: "Stripchat", AgeLimit: 18},
 	{Name: "stv:player"},
+	{Name: "Subsplash"},
+	{Name: "subsplash:playlist"},
 	{Name: "Substack"},
 	{Name: "SunPorno", AgeLimit: 18},
 	{Name: "sverigesradio:episode"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -739,7 +739,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -768,7 +768,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1060,7 +1060,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2061,7 +2061,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2815,7 +2815,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3165,15 +3165,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3194,11 +3194,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3219,7 +3219,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3249,7 +3249,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3277,7 +3277,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3958,11 +3958,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -3982,11 +3982,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4017,7 +4017,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4169,7 +4169,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4485,7 +4485,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.15/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2025.01.15`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.01.15) to [`2025.01.26`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.01.26).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.01.26)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.