### PR TITLE
update yt-dlp from 2025.01.26 to 2025.02.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2025.01.26
+export YTDLP_VERSION := 2025.02.19
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -574,7 +574,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2362,7 +2362,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3742,7 +3742,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4388,9 +4388,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4415,8 +4415,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4442,7 +4442,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4483,7 +4483,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4524,7 +4524,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5726,8 +5726,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5754,8 +5754,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5815,7 +5815,7 @@ var (
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -6086,7 +6086,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6650,7 +6650,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2025.01.26"
+	Version = "2025.02.19"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -346,7 +346,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "curiositystream", Description: "[curiositystream]"},
 	{Name: "curiositystream:collections", Description: "[curiositystream]"},
 	{Name: "curiositystream:series", Description: "[curiositystream]"},
-	{Name: "CWTV", AgeLimit: 14},
+	{Name: "cwtv", AgeLimit: 14},
+	{Name: "cwtv:movie", AgeLimit: 16},
 	{Name: "Cybrary", Description: "[cybrary]"},
 	{Name: "CybraryCourse", Description: "[cybrary]"},
 	{Name: "DacastPlaylist"},
@@ -381,6 +382,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "DigitalConcertHall", Description: "[digitalconcerthall] DigitalConcertHall extractor"},
 	{Name: "DigitallySpeaking"},
 	{Name: "Digiteka"},
+	{Name: "Digiview"},
 	{Name: "DiscogsReleasePlaylist"},
 	{Name: "DiscoveryLife"},
 	{Name: "DiscoveryNetworksDe"},
@@ -499,9 +501,9 @@ var SupportedExtractors = []*Extractor{
 	{Name: "fptplay", Description: "fptplay.vn"},
 	{Name: "FranceCulture"},
 	{Name: "FranceInter"},
-	{Name: "FranceTV"},
+	{Name: "francetv"},
+	{Name: "francetv:site"},
 	{Name: "francetvinfo.fr"},
-	{Name: "FranceTVSite"},
 	{Name: "Freesound"},
 	{Name: "freespeech.org"},
 	{Name: "freetv:series"},
@@ -531,9 +533,9 @@ var SupportedExtractors = []*Extractor{
 	{Name: "GBNews", Description: "GB News clips, features and live streams"},
 	{Name: "GDCVault", Description: "[gdcvault] (Currently broken)"},
 	{Name: "GediDigital"},
-	{Name: "gem.cbc.ca", Description: "[cbcgem]"},
+	{Name: "gem.cbc.ca", Description: "[cbcgem]", AgeLimit: 14},
 	{Name: "gem.cbc.ca:live"},
-	{Name: "gem.cbc.ca:playlist"},
+	{Name: "gem.cbc.ca:playlist", Description: "[cbcgem]"},
 	{Name: "generic:quoted-html", Description: "[HIDDEN]"},
 	{Name: "Genius"},
 	{Name: "GeniusLyrics"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -739,7 +739,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -768,7 +768,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1062,7 +1062,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2079,7 +2079,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2844,7 +2844,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3196,15 +3196,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3225,11 +3225,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3250,7 +3250,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3280,7 +3280,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3308,7 +3308,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3995,11 +3995,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -4019,11 +4019,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4054,7 +4054,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4208,7 +4208,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4524,7 +4524,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.01.26/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2025.01.26`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.01.26) to [`2025.02.19`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.02.19).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.02.19)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.