### PR TITLE
update yt-dlp from 2025.02.19 to 2025.03.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2025.02.19
+export YTDLP_VERSION := 2025.03.21
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -338,9 +338,8 @@ func (c *Command) ConfigLocations(path string) *Command {
 }
 
 // Path to an additional directory to search for plugins. This option can be used
-// multiple times to add multiple directories. Note that this currently only works
-// for extractor plugins; postprocessor plugins can only be loaded from the default
-// plugin directories
+// multiple times to add multiple directories. Use "default" to search the default
+// plugin directories (default)
 //
 // Additional information:
 //   - See [Command.UnsetPluginDirs], for unsetting the flag.
@@ -357,8 +356,25 @@ func (c *Command) PluginDirs(path string) *Command {
 
 // UnsetPluginDirs unsets any flags that were previously set by one of:
 //   - [Command.PluginDirs]
+//   - [Command.NoPluginDirs]
 func (c *Command) UnsetPluginDirs() *Command {
 	c.removeFlagByID("plugin_dirs")
+	return c
+}
+
+// Clear plugin directories to search, including defaults and those provided by
+// previous --plugin-dirs
+//
+// Additional information:
+//   - See [Command.UnsetPluginDirs], for unsetting the flag.
+//   - NoPluginDirs maps to cli flags: --no-plugin-dirs.
+//   - From option group: "General"
+func (c *Command) NoPluginDirs() *Command {
+	c.addFlag(&Flag{
+		ID:   "plugin_dirs",
+		Flag: "--no-plugin-dirs",
+		Args: nil,
+	})
 	return c
 }
 
@@ -574,7 +590,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2362,7 +2378,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3742,7 +3758,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4388,9 +4404,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4415,8 +4431,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4442,7 +4458,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4483,7 +4499,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4524,7 +4540,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5726,8 +5742,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5754,8 +5770,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5815,7 +5831,7 @@ var (
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -6086,7 +6102,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6650,7 +6666,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/builder.gen_test.go
+++ b/builder.gen_test.go
@@ -106,6 +106,12 @@ func TestBuilder_General_NonExecutable(t *testing.T) {
 		_ = builder.UnsetPluginDirs()
 		validateFlagRemoved(t, builder, "plugin_dirs", "--plugin-dirs")
 	})
+	t.Run("NoPluginDirs", func(t *testing.T) {
+		builder := New().NoPluginDirs()
+		validateFlagAdded(t, builder, "plugin_dirs", "--no-plugin-dirs", 0)
+		_ = builder.UnsetPluginDirs()
+		validateFlagRemoved(t, builder, "plugin_dirs", "--no-plugin-dirs")
+	})
 	t.Run("FlatPlaylist", func(t *testing.T) {
 		builder := New().FlatPlaylist()
 		validateFlagAdded(t, builder, "extract_flat", "--flat-playlist", 0)

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2025.02.19"
+	Version = "2025.03.21"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -249,6 +249,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "bt:vestlendingen", Description: "Bergens Tidende - Vestlendingen"},
 	{Name: "Bundesliga"},
 	{Name: "Bundestag"},
+	{Name: "BunnyCdn"},
 	{Name: "BusinessInsider"},
 	{Name: "BuzzFeed"},
 	{Name: "BYUtv", Description: "(Currently broken)"},
@@ -267,6 +268,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "CanalAlpha"},
 	{Name: "canalc2.tv"},
 	{Name: "Canalplus", Description: "mycanal.fr and piwiplus.fr"},
+	{Name: "Canalsurmas"},
 	{Name: "CaracolTvPlay", Description: "[caracoltv-play]"},
 	{Name: "CartoonNetwork"},
 	{Name: "cbc.ca"},
@@ -640,10 +642,10 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Inc"},
 	{Name: "IndavideoEmbed"},
 	{Name: "InfoQ"},
-	{Name: "Instagram", Description: "[instagram]"},
-	{Name: "instagram:story", Description: "[instagram]"},
-	{Name: "instagram:tag", Description: "[instagram] Instagram hashtag search URLs"},
-	{Name: "instagram:user", Description: "[instagram] Instagram user profile (Currently broken)"},
+	{Name: "Instagram"},
+	{Name: "instagram:story"},
+	{Name: "instagram:tag", Description: "Instagram hashtag search URLs"},
+	{Name: "instagram:user", Description: "Instagram user profile (Currently broken)"},
 	{Name: "InstagramIOS", Description: "IOS instagram:// URL"},
 	{Name: "Internazionale"},
 	{Name: "InternetVideoArchive"},
@@ -692,7 +694,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "KelbyOne", Description: "(Currently broken)"},
 	{Name: "Kenh14Playlist"},
 	{Name: "Kenh14Video"},
-	{Name: "Ketnet"},
 	{Name: "khanacademy"},
 	{Name: "khanacademy:unit"},
 	{Name: "kick:clips", AgeLimit: 18},
@@ -765,6 +766,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Livestreamfails"},
 	{Name: "Lnk"},
 	{Name: "loc", Description: "Library of Congress"},
+	{Name: "Loco"},
 	{Name: "loom"},
 	{Name: "loom:folder"},
 	{Name: "LoveHomePorn", AgeLimit: 18},
@@ -864,7 +866,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "MoviewPlay"},
 	{Name: "Moviezine"},
 	{Name: "MovingImage"},
-	{Name: "MSN", Description: "(Currently broken)"},
+	{Name: "MSN"},
 	{Name: "mtg", Description: "MTG services"},
 	{Name: "mtv"},
 	{Name: "mtv.de", Description: "(Currently broken)"},
@@ -1378,6 +1380,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Smotrim"},
 	{Name: "SnapchatSpotlight"},
 	{Name: "Snotr"},
+	{Name: "SoftWhiteUnderbelly", Description: "[softwhiteunderbelly]"},
 	{Name: "Sohu"},
 	{Name: "SohuV"},
 	{Name: "SonyLIV", Description: "[sonyliv]"},
@@ -1574,6 +1577,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "tv5unis", AgeLimit: 8},
 	{Name: "tv5unis:video"},
 	{Name: "tv8.it"},
+	{Name: "tv8.it:live", Description: "TV8 Live"},
+	{Name: "tv8.it:playlist", Description: "TV8 Playlist"},
 	{Name: "TVANouvelles"},
 	{Name: "TVANouvellesArticle"},
 	{Name: "tvaplus", Description: "TVA+"},
@@ -1594,6 +1599,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "tvp:vod:series", AgeLimit: 12},
 	{Name: "TVPlayer"},
 	{Name: "TVPlayHome"},
+	{Name: "Tvw"},
 	{Name: "Tweakers"},
 	{Name: "TwitCasting"},
 	{Name: "TwitCastingLive"},
@@ -1717,7 +1723,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "vqq:series"},
 	{Name: "vqq:video"},
 	{Name: "VRT", Description: "VRT NWS, Flanders News, Flandern Info and Sporza"},
-	{Name: "VrtNU", Description: "[vrtnu] VRT MAX", AgeLimit: 12},
+	{Name: "vrtmax", Description: "[vrtnu] VRT MAX (formerly VRT NU)"},
 	{Name: "VTM", Description: "(Currently broken)"},
 	{Name: "VTV"},
 	{Name: "VTVGo"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -48,6 +48,7 @@ var (
 			optionNoConfigLocations,
 			optionConfigLocations,
 			optionPluginDirs,
+			optionNoPluginDirs,
 			optionFlatPlaylist,
 			optionNoFlatPlaylist,
 			optionLiveFromStart,
@@ -432,6 +433,7 @@ var Options = []*Option{
 	optionNoConfigLocations,
 	optionConfigLocations,
 	optionPluginDirs,
+	optionNoPluginDirs,
 	optionFlatPlaylist,
 	optionNoFlatPlaylist,
 	optionLiveFromStart,
@@ -739,7 +741,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -768,7 +770,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -931,11 +933,22 @@ var (
 		DefaultFlag:    "--plugin-dirs",
 		ArgNames:       []string{"path"},
 		Executable:     false,
-		Help:           "Path to an additional directory to search for plugins. This option can be used multiple times to add multiple directories. Note that this currently only works for extractor plugins; postprocessor plugins can only be loaded from the default plugin directories",
+		Help:           "Path to an additional directory to search for plugins. This option can be used multiple times to add multiple directories. Use \"default\" to search the default plugin directories (default)",
 		MetaArgs:       "PATH",
 		Type:           "string",
 		LongFlags:      []string{"--plugin-dirs"},
 		NArgs:          1,
+	}
+	optionNoPluginDirs = &Option{
+		ID:             "plugin_dirs",
+		Name:           "no-plugin-dirs",
+		NameCamelCase:  "noPluginDirs",
+		NamePascalCase: "NoPluginDirs",
+		DefaultFlag:    "--no-plugin-dirs",
+		Executable:     false,
+		Help:           "Clear plugin directories to search, including defaults and those provided by previous --plugin-dirs",
+		Type:           "bool",
+		LongFlags:      []string{"--no-plugin-dirs"},
 	}
 	optionFlatPlaylist = &Option{
 		ID:             "extract_flat",
@@ -1062,7 +1075,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2079,7 +2092,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2844,7 +2857,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3196,15 +3209,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3225,11 +3238,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3250,7 +3263,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3280,7 +3293,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3308,7 +3321,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -3995,11 +4008,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -4019,11 +4032,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4054,7 +4067,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4208,7 +4221,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4524,7 +4537,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.02.19/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2025.02.19`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.02.19) to [`2025.03.21`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.21).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.21)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.