### PR TITLE
update yt-dlp from 2025.03.21 to 2025.03.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2025.03.21
+export YTDLP_VERSION := 2025.03.25
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -590,7 +590,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2378,7 +2378,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3758,7 +3758,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4404,9 +4404,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4431,8 +4431,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4458,7 +4458,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4499,7 +4499,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4540,7 +4540,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5742,8 +5742,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5770,8 +5770,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5831,7 +5831,7 @@ var (
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -6102,7 +6102,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6666,7 +6666,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2025.03.21"
+	Version = "2025.03.25"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -31,6 +31,7 @@ type Extractor struct {
 var SupportedExtractors = []*Extractor{
 	{Name: "17live"},
 	{Name: "17live:clip"},
+	{Name: "17live:vod"},
 	{Name: "1News", Description: "1news.co.nz article videos"},
 	{Name: "1tv", Description: "Первый канал"},
 	{Name: "20min"},
@@ -225,7 +226,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "blogger.com"},
 	{Name: "Bloomberg"},
 	{Name: "Bluesky", AgeLimit: 18},
-	{Name: "BokeCC"},
+	{Name: "BokeCC", Description: "CC视频"},
 	{Name: "BongaCams", AgeLimit: 18},
 	{Name: "Boosty"},
 	{Name: "BostonGlobe"},
@@ -373,8 +374,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "daystar:clip"},
 	{Name: "DBTV"},
 	{Name: "DctpTv"},
-	{Name: "DeezerAlbum"},
-	{Name: "DeezerPlaylist"},
 	{Name: "democracynow"},
 	{Name: "DestinationAmerica"},
 	{Name: "DetikEmbed"},
@@ -862,7 +861,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "MotherlessUploader"},
 	{Name: "Motorsport", Description: "motorsport.com (Currently broken)"},
 	{Name: "MovieFap", AgeLimit: 18},
-	{Name: "Moviepilot"},
+	{Name: "moviepilot", Description: "Moviepilot trailer"},
 	{Name: "MoviewPlay"},
 	{Name: "Moviezine"},
 	{Name: "MovingImage"},
@@ -1343,8 +1342,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "sejm"},
 	{Name: "Sen"},
 	{Name: "SenalColombiaLive", Description: "(Currently broken)"},
-	{Name: "SenateGov"},
-	{Name: "SenateISVP"},
+	{Name: "senate.gov"},
+	{Name: "senate.gov:isvp"},
 	{Name: "SendtoNews", Description: "(Currently broken)"},
 	{Name: "Servus"},
 	{Name: "Sexu", Description: "(Currently broken)", AgeLimit: 18},
@@ -1437,6 +1436,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "StoryFire"},
 	{Name: "StoryFireSeries"},
 	{Name: "StoryFireUser"},
+	{Name: "Streaks"},
 	{Name: "Streamable"},
 	{Name: "StreamCZ"},
 	{Name: "StreetVoice"},
@@ -1683,8 +1683,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "viewlift:embed"},
 	{Name: "ViewSource", Description: "[HIDDEN]"},
 	{Name: "Viidea"},
-	{Name: "viki", Description: "[viki]", AgeLimit: 13},
-	{Name: "viki:channel", Description: "[viki]"},
 	{Name: "vimeo", Description: "[vimeo]"},
 	{Name: "vimeo:album", Description: "[vimeo]"},
 	{Name: "vimeo:channel", Description: "[vimeo]"},
@@ -1722,6 +1720,10 @@ var SupportedExtractors = []*Extractor{
 	{Name: "vpro", Description: "npo.nl, ntr.nl, omroepwnl.nl, zapp.nl and npo3.nl"},
 	{Name: "vqq:series"},
 	{Name: "vqq:video"},
+	{Name: "vrsquare", Description: "VR SQUARE"},
+	{Name: "vrsquare:channel"},
+	{Name: "vrsquare:search"},
+	{Name: "vrsquare:section"},
 	{Name: "VRT", Description: "VRT NWS, Flanders News, Flandern Info and Sporza"},
 	{Name: "vrtmax", Description: "[vrtnu] VRT MAX (formerly VRT NU)"},
 	{Name: "VTM", Description: "(Currently broken)"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -741,7 +741,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -770,7 +770,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1075,7 +1075,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2092,7 +2092,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2857,7 +2857,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3209,15 +3209,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3238,11 +3238,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3263,7 +3263,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3293,7 +3293,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3321,7 +3321,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -4008,11 +4008,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -4032,11 +4032,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4067,7 +4067,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4221,7 +4221,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4537,7 +4537,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.21/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.03.25/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2025.03.21`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.21) to [`2025.03.25`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.25).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.25)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.