### PR TITLE
update yt-dlp from 2025.04.30 to 2025.05.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2025.04.30
+export YTDLP_VERSION := 2025.05.22
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -30,7 +30,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#update
 //
 // Additional information:
 //   - Update maps to cli flags: -U/--update.
@@ -72,7 +72,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#update
+//   - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#update
 //
 // Additional information:
 //   - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -417,8 +417,8 @@ func (c *Command) NoFlatPlaylist() *Command {
 	return c
 }
 
-// Download livestreams from the start. Currently only supported for YouTube
-// (Experimental)
+// Download livestreams from the start. Currently experimental and only supported
+// for YouTube and Twitch
 //
 // Additional information:
 //   - See [Command.UnsetLiveFromStart], for unsetting the flag.
@@ -590,7 +590,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#differences-in-default-behavior
+//   - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#differences-in-default-behavior
 //
 // Additional information:
 //   - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2402,7 +2402,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetOutput], for unsetting the flag.
@@ -3782,7 +3782,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -4428,9 +4428,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection
-//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#filtering-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection-examples
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection
+//   - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#filtering-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormat], for unsetting the flag.
@@ -4455,8 +4455,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#sorting-formats
-//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection-examples
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#sorting-formats
+//   - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection-examples
 //
 // Additional information:
 //   - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -4482,7 +4482,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#sorting-formats
+//   - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#sorting-formats
 //
 // Additional information:
 //   - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -4523,7 +4523,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -4564,7 +4564,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection
+//   - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection
 //
 // Additional information:
 //   - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -5766,8 +5766,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -5794,8 +5794,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata
-//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata-examples
+//   - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata
+//   - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata-examples
 //
 // Additional information:
 //   - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5855,7 +5855,7 @@ var (
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -6126,7 +6126,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template
+//   - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template
 //
 // Additional information:
 //   - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -6690,7 +6690,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#extractor-arguments
+//   - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#extractor-arguments
 //
 // Additional information:
 //   - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2025.04.30"
+	Version = "2025.05.22"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -271,7 +271,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Canalplus", Description: "mycanal.fr and piwiplus.fr"},
 	{Name: "Canalsurmas"},
 	{Name: "CaracolTvPlay", Description: "[caracoltv-play]"},
-	{Name: "CartoonNetwork"},
 	{Name: "cbc.ca"},
 	{Name: "cbc.ca:player"},
 	{Name: "cbc.ca:player:playlist"},
@@ -680,7 +679,10 @@ var SupportedExtractors = []*Extractor{
 	{Name: "jiocinema", Description: "[jiocinema]", AgeLimit: 13},
 	{Name: "jiocinema:series", Description: "[jiocinema]"},
 	{Name: "jiosaavn:album"},
+	{Name: "jiosaavn:artist"},
 	{Name: "jiosaavn:playlist"},
+	{Name: "jiosaavn:show"},
+	{Name: "jiosaavn:show:playlist"},
 	{Name: "jiosaavn:song"},
 	{Name: "Joj"},
 	{Name: "JoqrAg", Description: "超!A&G+ 文化放送 (f.k.a. AGQR) Nippon Cultural Broadcasting, Inc. (JOQR)"},
@@ -1114,8 +1116,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Photobucket"},
 	{Name: "PiaLive"},
 	{Name: "Piapro", Description: "[piapro]"},
-	{Name: "Picarto"},
-	{Name: "PicartoVod", AgeLimit: 18},
+	{Name: "picarto"},
+	{Name: "picarto:vod", AgeLimit: 18},
 	{Name: "Piksel"},
 	{Name: "Pinkbike"},
 	{Name: "Pinterest"},
@@ -1426,7 +1428,6 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Spreaker"},
 	{Name: "SpreakerShow"},
 	{Name: "SpringboardPlatform"},
-	{Name: "Sprout"},
 	{Name: "SproutVideo"},
 	{Name: "sr:mediathek", Description: "Saarländischer Rundfunk (Currently broken)"},
 	{Name: "SRGSSR"},
@@ -1696,6 +1697,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "vimeo", Description: "[vimeo]"},
 	{Name: "vimeo:album", Description: "[vimeo]"},
 	{Name: "vimeo:channel", Description: "[vimeo]"},
+	{Name: "vimeo:event", Description: "[vimeo]"},
 	{Name: "vimeo:group", Description: "[vimeo]"},
 	{Name: "vimeo:likes", Description: "[vimeo] Vimeo user likes"},
 	{Name: "vimeo:ondemand", Description: "[vimeo]"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -744,7 +744,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -773,7 +773,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -982,7 +982,7 @@ var (
 		NamePascalCase: "LiveFromStart",
 		DefaultFlag:    "--live-from-start",
 		Executable:     false,
-		Help:           "Download livestreams from the start. Currently only supported for YouTube (Experimental)",
+		Help:           "Download livestreams from the start. Currently experimental and only supported for YouTube and Twitch",
 		Type:           "bool",
 		LongFlags:      []string{"--live-from-start"},
 	}
@@ -1078,7 +1078,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2110,7 +2110,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -2875,7 +2875,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3227,15 +3227,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3256,11 +3256,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3281,7 +3281,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3311,7 +3311,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3339,7 +3339,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -4026,11 +4026,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -4050,11 +4050,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4085,7 +4085,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4239,7 +4239,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4555,7 +4555,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.04.30/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.05.22/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2025.04.30`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.04.30) to [`2025.05.22`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.05.22).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.05.22)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.