### PR TITLE
update yt-dlp from 2025.08.27 to 2025.09.05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2025.08.27
+export YTDLP_VERSION := 2025.09.05
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -27,7 +27,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#update
+//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#update
 //
 // Additional information:
 //  - Update maps to cli flags: -U/--update.
@@ -59,7 +59,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#update
+//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#update
 //
 // Additional information:
 //  - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -501,7 +501,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//  - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#differences-in-default-behavior
+//  - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#differences-in-default-behavior
 //
 // Additional information:
 //  - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2074,7 +2074,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetOutput], for unsetting the flag.
@@ -3266,7 +3266,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -3796,9 +3796,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection
-//  - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#filtering-formats
-//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection-examples
+//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection
+//  - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#filtering-formats
+//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection-examples
 //
 // Additional information:
 //  - See [Command.UnsetFormat], for unsetting the flag.
@@ -3821,8 +3821,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#sorting-formats
-//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection-examples
+//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#sorting-formats
+//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection-examples
 //
 // Additional information:
 //  - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -3844,7 +3844,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#sorting-formats
+//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#sorting-formats
 //
 // Additional information:
 //  - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -3880,7 +3880,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection
+//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection
 //
 // Additional information:
 //  - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -3916,7 +3916,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection
+//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection
 //
 // Additional information:
 //  - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -4947,8 +4947,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata
-//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata-examples
+//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata
+//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata-examples
 //
 // Additional information:
 //  - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -4973,8 +4973,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata
-//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata-examples
+//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata
+//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata-examples
 //
 // Additional information:
 //  - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -5039,7 +5039,7 @@ var AllConcatPlaylistOptions = []ConcatPlaylistOption{
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5285,7 +5285,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -5774,7 +5774,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//  - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#extractor-arguments
+//  - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#extractor-arguments
 //
 // Additional information:
 //  - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2025.08.27"
+	Version = "2025.09.05"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -691,7 +691,7 @@ var SupportedExtractors = []*Extractor{
 	{Name: "khanacademy:unit"},
 	{Name: "kick:clips", AgeLimit: 18},
 	{Name: "kick:live", AgeLimit: 18},
-	{Name: "kick:vod"},
+	{Name: "kick:vod", AgeLimit: 18},
 	{Name: "Kicker"},
 	{Name: "KickStarter"},
 	{Name: "Kika", Description: "KiKA.de"},
@@ -1640,6 +1640,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "Vbox7"},
 	{Name: "Veo"},
 	{Name: "Vesti", Description: "Вести.Ru (Currently broken)"},
+	{Name: "Vevo", AgeLimit: 18},
+	{Name: "VevoPlaylist"},
 	{Name: "VGTV", Description: "VGTV, BTTV, FTV, Aftenposten and Aftonbladet"},
 	{Name: "vh1.com"},
 	{Name: "vhx:embed", Description: "[vimeo]"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -746,7 +746,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -777,7 +777,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -1107,7 +1107,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -2218,7 +2218,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -3047,7 +3047,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -3427,15 +3427,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -3457,11 +3457,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -3483,7 +3483,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -3515,7 +3515,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -3545,7 +3545,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -4287,11 +4287,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -4312,11 +4312,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -4349,7 +4349,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -4514,7 +4514,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -4855,7 +4855,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.08.27/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2025.09.05/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2025.08.27`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.08.27) to [`2025.09.05`](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.09.05).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.09.05)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.