### PR TITLE
fix(results): requested_subtitles holds one subtitle object per language

### DIFF
--- a/results.go
+++ b/results.go
@@ -472,8 +472,12 @@ type ExtractedInfo struct {
 
 	// Subtitles contains the available subtitles, where the key is the language
 	// code, and the value is a list of subtitle formats.
-	Subtitles          map[string][]*ExtractedSubtitle `json:"subtitles,omitempty"`
-	RequestedSubtitles map[string][]*ExtractedSubtitle `json:"requested_subtitles,omitempty"`
+	Subtitles map[string][]*ExtractedSubtitle `json:"subtitles,omitempty"`
+
+	// RequestedSubtitles contains the subtitles selected for download, where the
+	// key is the language code, and the value is the single chosen subtitle
+	// format (yt-dlp's process_subtitles picks one format per language).
+	RequestedSubtitles map[string]*ExtractedSubtitle `json:"requested_subtitles,omitempty"`
 
 	// AutomaticCaptions contains the automatically generated captions instead of
 	// normal subtitles.

--- a/results_test.go
+++ b/results_test.go
@@ -6,6 +6,7 @@ package ytdlp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -103,4 +104,25 @@ func TestExtractedInfo(t *testing.T) {
 
 	require.NotNil(t, info[0].ExtractorKey, "expected extractor key to be set")
 	assert.Equal(t, "Generic", *info[0].ExtractorKey, "expected extractor key to be generic")
+}
+
+func TestParseExtractedInfo_requestedSubtitles(t *testing.T) {
+	// yt-dlp's process_subtitles selects a single subtitle format per language,
+	// so requested_subtitles holds one object per language, while subtitles and
+	// automatic_captions hold a list of formats per language.
+	raw := json.RawMessage(`{
+		"id": "sample-1",
+		"subtitles": {"en": [{"ext": "vtt", "url": "https://example.com/en.vtt"}, {"ext": "srt", "url": "https://example.com/en.srt"}]},
+		"automatic_captions": {"en": [{"ext": "vtt", "url": "https://example.com/auto-en.vtt"}]},
+		"requested_subtitles": {"en": {"ext": "srt", "url": "https://example.com/en.srt", "name": "English"}}
+	}`)
+
+	info, err := ParseExtractedInfo(&raw)
+	require.NoError(t, err, "expected requested_subtitles to unmarshal")
+
+	require.Contains(t, info.RequestedSubtitles, "en", "expected en requested subtitle")
+	assert.Equal(t, "https://example.com/en.srt", info.RequestedSubtitles["en"].URL, "expected en requested subtitle url")
+
+	require.Len(t, info.Subtitles["en"], 2, "expected 2 en subtitle formats")
+	require.Len(t, info.AutomaticCaptions["en"], 1, "expected 1 en automatic caption format")
 }


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

`ExtractedInfo.RequestedSubtitles` is typed `map[string][]*ExtractedSubtitle`, but yt-dlp emits a single subtitle object per language for this field. `ParseExtractedInfo` fails when a run requests subtitles (`--write-subs` / `--write-auto-subs`) and yt-dlp selects one:

```
json: cannot unmarshal object into Go struct field ExtractedInfo.requested_subtitles of type []*ytdlp.ExtractedSubtitle
```

This PR changes the type to `map[string]*ExtractedSubtitle`, documents the field, and adds a regression test covering all three subtitle fields.

yt-dlp source (tag 2026.07.04):

- [`YoutubeDL.py:2920`](https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/yt_dlp/YoutubeDL.py#L2920) sets the field: `info_dict['requested_subtitles'] = self.process_subtitles(...)`
- [`YoutubeDL.py:3217-3218`](https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/yt_dlp/YoutubeDL.py#L3217-L3218) shows `process_subtitles` selecting one format per language and returning `{lang: format_dict}`: `subs[lang] = f`, then `return subs`

The sibling fields differ by design. Extractors produce `subtitles` and `automatic_captions` as `{lang: [format, ...]}` (a language can offer vtt, srt, json3, ...), so their `map[string][]*ExtractedSubtitle` type is correct. `requested_subtitles` is the post-selection result: one chosen format per language.

Reproduce. The failure requires a selected subtitle: when nothing matches, yt-dlp sets `requested_subtitles` to `null`, which unmarshals into the Go map without error. This sample video has auto captions only, hence `--write-auto-subs`; a video with manual subtitles reproduces with `--write-subs` alone.

```
yt-dlp --skip-download --write-subs --write-auto-subs --sub-langs en -J "https://www.youtube.com/watch?v=_pkq3z-5zy0" | python3 -c "import json,sys; print(json.load(sys.stdin)['requested_subtitles'])"
# {'en': {'ext': 'vtt', 'url': '...', 'name': 'English'}}  <- object, not list
```

### 🔗 Related bug reports/feature requests

- fixes #126

### 🧰 Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

### 📝 Notes to reviewer

The field's Go type changes, but no working code depends on the old one: the old type never unmarshals, so `ParseExtractedInfo` returned an error before a caller could read the field.

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [x] 🧪 I have included tests (if necessary) for this change.
