### PR TITLE
fix: enable JSON parsing for --dump-single-json

### DIFF
--- a/command.go
+++ b/command.go
@@ -161,6 +161,9 @@ func (c *Command) hasJSONFlag() bool {
 	if v := c.flagConfig.VerbositySimulation.DumpJSON; v != nil && *v {
 		return true
 	}
+	if v := c.flagConfig.VerbositySimulation.DumpSingleJSON; v != nil && *v {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
`hasJSONFlag()` enables `stdout.checkJSON` for `--print %(j)s`, `--print-json`, and `--dump-json`, but not for `--dump-single-json`. As a result, `Result.GetExtractedInfo()` returns nothing when a command uses `DumpSingleJSON()` — the stdout line (valid JSON) is never flagged as JSON, so it is skipped. This adds `DumpSingleJSON` to the condition.

### Before / after

Repro: `ytdlp.New().DumpSingleJSON().FlatPlaylist().Run(ctx, "<playlist URL>")`, then `GetExtractedInfo()`.

Before:

```
OutputLogs: 1 | with JSON: 0
GetExtractedInfo len: 0
```

After:

```
OutputLogs: 1 | with JSON: 1
GetExtractedInfo len: 1
```

Fixes #128
