### PR TITLE
update yt-dlp from 2026.07.04 to 2026.08.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := generate
 
-export YTDLP_VERSION := 2026.07.04
+export YTDLP_VERSION := 2026.08.19
 
 license:
 	curl -sL https://liam.sh/-/gh/g/license-header.sh | bash -s

--- a/builder.gen.go
+++ b/builder.gen.go
@@ -27,7 +27,7 @@ func (c *Command) Version(ctx context.Context) (*Result, error) {
 // Use git to pull the latest changes
 //
 // References:
-//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#update
+//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#update
 //
 // Additional information:
 //  - Update maps to cli flags: -U/--update.
@@ -59,7 +59,7 @@ func (c *Command) UnsetUpdate() *Command {
 // "UPDATE" for details. Supported channels: stable, nightly, master
 //
 // References:
-//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#update
+//  - Update Notes: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#update
 //
 // Additional information:
 //  - UpdateTo maps to cli flags: --update-to=[CHANNEL]@[TAG].
@@ -569,7 +569,7 @@ func (c *Command) UnsetColor() *Command {
 // in default behavior" for details
 //
 // References:
-//  - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#differences-in-default-behavior
+//  - Compatibility Options: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#differences-in-default-behavior
 //
 // Additional information:
 //  - See [Command.UnsetCompatOptions], for unsetting the flag.
@@ -2063,7 +2063,7 @@ func (c *Command) UnsetPaths() *Command {
 // Output filename template; see "OUTPUT TEMPLATE" for details
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetOutput], for unsetting the flag.
@@ -3216,7 +3216,7 @@ func (c *Command) UnsetGetFormat() *Command {
 // is used. See "OUTPUT TEMPLATE" for a description of available keys
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetDumpJSON], for unsetting the flag.
@@ -3706,9 +3706,9 @@ func (c *Command) UnsetSleepSubtitles() *Command {
 // Video format code, see "FORMAT SELECTION" for more details
 //
 // References:
-//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection
-//  - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#filtering-formats
-//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection-examples
+//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection
+//  - Filter Formatting: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#filtering-formats
+//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection-examples
 //
 // Additional information:
 //  - See [Command.UnsetFormat], for unsetting the flag.
@@ -3731,8 +3731,8 @@ func (c *Command) UnsetFormat() *Command {
 // Sort the formats by the fields given, see "Sorting Formats" for more details
 //
 // References:
-//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#sorting-formats
-//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection-examples
+//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#sorting-formats
+//  - Format Selection Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection-examples
 //
 // Additional information:
 //  - See [Command.UnsetFormatSort], for unsetting the flag.
@@ -3754,7 +3754,7 @@ func (c *Command) UnsetFormatSort() *Command {
 // Formats" for more details
 //
 // References:
-//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#sorting-formats
+//  - Sorting Formats: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#sorting-formats
 //
 // Additional information:
 //  - See [Command.UnsetFormatSortForce], for unsetting the flag.
@@ -3790,7 +3790,7 @@ func (c *Command) NoFormatSortForce() *Command {
 // Allow multiple video streams to be merged into a single file
 //
 // References:
-//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection
+//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection
 //
 // Additional information:
 //  - See [Command.UnsetVideoMultistreams], for unsetting the flag.
@@ -3826,7 +3826,7 @@ func (c *Command) NoVideoMultistreams() *Command {
 // Allow multiple audio streams to be merged into a single file
 //
 // References:
-//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection
+//  - Format Selection: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection
 //
 // Additional information:
 //  - See [Command.UnsetAudioMultistreams], for unsetting the flag.
@@ -4857,8 +4857,8 @@ func (c *Command) UnsetMetadataFromTitle() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata
-//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata-examples
+//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata
+//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata-examples
 //
 // Additional information:
 //  - See [Command.UnsetParseMetadata], for unsetting the flag.
@@ -4883,8 +4883,8 @@ func (c *Command) UnsetParseMetadata() *Command {
 // --use-postprocessor (default: pre_process)
 //
 // References:
-//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata
-//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata-examples
+//  - Modifying Metadata: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata
+//  - Modifying Metadata Examples: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata-examples
 //
 // Additional information:
 //  - See [Command.UnsetReplaceInMetadata], for unsetting the flag.
@@ -4949,7 +4949,7 @@ var AllConcatPlaylistOptions = []ConcatPlaylistOption{
 // the concatenated files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetConcatPlaylist], for unsetting the flag.
@@ -5149,7 +5149,7 @@ func (c *Command) UnsetConvertThumbnails() *Command {
 // the split files. See "OUTPUT TEMPLATE" for details
 //
 // References:
-//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template
+//  - Output Template: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template
 //
 // Additional information:
 //  - See [Command.UnsetSplitChapters], for unsetting the flag.
@@ -5477,7 +5477,7 @@ func (c *Command) NoHLSSplitDiscontinuity() *Command {
 // extractors
 //
 // References:
-//  - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#extractor-arguments
+//  - Extractor Arguments: https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#extractor-arguments
 //
 // Additional information:
 //  - See [Command.UnsetExtractorArgs], for unsetting the flag.

--- a/constants.gen.go
+++ b/constants.gen.go
@@ -11,7 +11,7 @@ const (
 	Channel = "stable"
 
 	// Version of yt-dlp that go-ytdlp was generated with.
-	Version = "2026.07.04"
+	Version = "2026.08.19"
 )
 
 // Extractor contains information about a specific yt-dlp extractor. Extractors are
@@ -108,10 +108,9 @@ var SupportedExtractors = []*Extractor{
 	{Name: "APA"},
 	{Name: "Aparat"},
 	{Name: "apple:music:connect", Description: "Apple Music Connect"},
-	{Name: "ApplePodcasts"},
+	{Name: "apple:podcasts", Description: "Apple Podcasts"},
 	{Name: "archive.org", Description: "archive.org video and audio"},
 	{Name: "ArcPublishing"},
-	{Name: "ARD"},
 	{Name: "ARDAudiothek"},
 	{Name: "ARDAudiothekPlaylist"},
 	{Name: "ARDMediathek"},
@@ -1274,7 +1273,8 @@ var SupportedExtractors = []*Extractor{
 	{Name: "SharePoint"},
 	{Name: "ShemarooMe"},
 	{Name: "Shiey"},
-	{Name: "ShowRoomLive", Description: "(Currently broken)"},
+	{Name: "showroom:live", Description: "SHOWROOM"},
+	{Name: "showroom:vod"},
 	{Name: "ShugiinItvLive", Description: "衆議院インターネット審議中継"},
 	{Name: "ShugiinItvLiveRoom", Description: "衆議院インターネット審議中継 (中継)"},
 	{Name: "ShugiinItvVod", Description: "衆議院インターネット審議中継 (ビデオライブラリ)"},

--- a/optiondata/optiondata.gen.go
+++ b/optiondata/optiondata.gen.go
@@ -1706,7 +1706,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#update",
 			},
 		},
 		DefaultFlag: "--update",
@@ -1737,7 +1737,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Update Notes",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#update",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#update",
 			},
 		},
 		DefaultFlag: "--update-to",
@@ -2111,7 +2111,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Compatibility Options",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#differences-in-default-behavior",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#differences-in-default-behavior",
 			},
 		},
 		DefaultFlag: "--compat-options",
@@ -3168,7 +3168,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--output",
@@ -3971,7 +3971,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--dump-json",
@@ -4324,15 +4324,15 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection",
 			},
 			{
 				Name: "Filter Formatting",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#filtering-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#filtering-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format",
@@ -4354,11 +4354,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#sorting-formats",
 			},
 			{
 				Name: "Format Selection Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection-examples",
 			},
 		},
 		DefaultFlag: "--format-sort",
@@ -4380,7 +4380,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Sorting Formats",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#sorting-formats",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#sorting-formats",
 			},
 		},
 		DefaultFlag: "--format-sort-force",
@@ -4412,7 +4412,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--video-multistreams",
@@ -4442,7 +4442,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Format Selection",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#format-selection",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#format-selection",
 			},
 		},
 		DefaultFlag: "--audio-multistreams",
@@ -5184,11 +5184,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--parse-metadata",
@@ -5209,11 +5209,11 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Modifying Metadata",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata",
 			},
 			{
 				Name: "Modifying Metadata Examples",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#modifying-metadata-examples",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#modifying-metadata-examples",
 			},
 		},
 		DefaultFlag: "--replace-in-metadata",
@@ -5246,7 +5246,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--concat-playlist",
@@ -5385,7 +5385,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Output Template",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#output-template",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#output-template",
 			},
 		},
 		DefaultFlag: "--split-chapters",
@@ -5616,7 +5616,7 @@ var (
 		URLs: []*OptionURL{
 			{
 				Name: "Extractor Arguments",
-				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.07.04/README.md#extractor-arguments",
+				URL:  "https://github.com/yt-dlp/yt-dlp/blob/2026.08.19/README.md#extractor-arguments",
 			},
 		},
 		DefaultFlag: "--extractor-args",


### PR DESCRIPTION
Updating tool [`yt-dlp`](https://github.com/yt-dlp/yt-dlp):

- Bumping **version** from [`2026.07.04`](https://github.com/yt-dlp/yt-dlp/releases/tag/2026.07.04) to [`2026.08.19`](https://github.com/yt-dlp/yt-dlp/releases/tag/2026.08.19).

Release notes: [link](https://github.com/yt-dlp/yt-dlp/releases/tag/2026.08.19)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.